### PR TITLE
Use positional file arguments for add-dependency and fix-dpr

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ It now supports two modes:
 ## Usage
 
 ```powershell
-fixdpr add-dependency --search-path PATH [--search-path PATH] --new-dependency VALUE [--delphi-path PATH] [--delphi-version VERSION] [--ignore-path PATH] [--ignore-dpr GLOB] [--disable-introduced-dependencies] [--fix-updated-dprs] [--show-infos] [--show-warnings]
+fixdpr add-dependency --search-path PATH [--search-path PATH] NEW_DEPENDENCY [--delphi-path PATH] [--delphi-version VERSION] [--ignore-path PATH] [--ignore-dpr GLOB] [--disable-introduced-dependencies] [--fix-updated-dprs] [--show-infos] [--show-warnings]
 ```
 
 ```powershell
-fixdpr fix-dpr --search-path PATH [--search-path PATH] --dpr-file FILE [--delphi-path PATH] [--delphi-version VERSION] [--ignore-path PATH] [--ignore-dpr GLOB] [--show-infos] [--show-warnings]
+fixdpr fix-dpr --search-path PATH [--search-path PATH] DPR_FILE [--delphi-path PATH] [--delphi-version VERSION] [--ignore-path PATH] [--ignore-dpr GLOB] [--show-infos] [--show-warnings]
 ```
 
 ## Arguments
@@ -31,20 +31,20 @@ fixdpr fix-dpr --search-path PATH [--search-path PATH] --dpr-file FILE [--delphi
 
 ### `add-dependency` arguments
 
-- `--new-dependency VALUE`: A `.pas` file path (absolute or relative to the current working directory).
-- `--disable-introduced-dependencies`: Disable inserting transitive dependencies referenced by `--new-dependency`; by default, these introduced dependencies are also inserted when needed.
+- `NEW_DEPENDENCY`: A `.pas` file path (absolute or relative to the current working directory).
+- `--disable-introduced-dependencies`: Disable inserting transitive dependencies referenced by `NEW_DEPENDENCY`; by default, these introduced dependencies are also inserted when needed.
 - `--fix-updated-dprs`: After `add-dependency` updates files, run `fix-dpr` behavior on each updated `.dpr` to add additional missing dependencies from the search-path unit cache.
 
 ### `fix-dpr` arguments
 
-- `--dpr-file FILE`: Target `.dpr` file to repair (absolute or relative to the current working directory).
+- `DPR_FILE`: Target `.dpr` file to repair (absolute or relative to the current working directory).
 
 ## Examples
 
 Add a new dependency for all matching `.dpr` files:
 
 ```powershell
-fixdpr add-dependency --search-path .\repo --new-dependency .\repo\common\NewUnit.pas
+fixdpr add-dependency --search-path .\repo .\repo\common\NewUnit.pas
 ```
 
 Add dependency using Delphi fallback roots:
@@ -52,7 +52,7 @@ Add dependency using Delphi fallback roots:
 ```powershell
 fixdpr add-dependency `
   --search-path .\repo `
-  --new-dependency C:\RADStudio\source\rtl\common\System.Net.HttpClient.pas `
+  C:\RADStudio\source\rtl\common\System.Net.HttpClient.pas `
   --delphi-path C:\RADStudio\source\rtl\common `
   --delphi-path C:\RADStudio\source\vcl
 ```
@@ -62,7 +62,7 @@ Add dependency and then run fix pass on all updated `.dpr` files:
 ```powershell
 fixdpr add-dependency `
   --search-path .\repo `
-  --new-dependency .\repo\common\NewUnit.pas `
+  .\repo\common\NewUnit.pas `
   --fix-updated-dprs
 ```
 
@@ -71,7 +71,7 @@ Repair one `.dpr` by adding missing dependencies from search-path units:
 ```powershell
 fixdpr fix-dpr `
   --search-path .\repo `
-  --dpr-file .\repo\app1\App1.dpr
+  .\repo\app1\App1.dpr
 ```
 
 Repair one `.dpr` while honoring ignored paths/patterns:
@@ -80,7 +80,7 @@ Repair one `.dpr` while honoring ignored paths/patterns:
 fixdpr fix-dpr `
   --search-path .\repo `
   --delphi-path C:\RADStudio\source\rtl\common `
-  --dpr-file .\repo\app1\App1.dpr `
+  .\repo\app1\App1.dpr `
   --ignore-path .\repo\ignored `
   --ignore-dpr ".\repo\legacy\**\*.dpr"
 ```

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -19,7 +19,6 @@ fn end_to_end_updates_expected_dprs() {
         .arg("add-dependency")
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .arg("--ignore-path")
         .arg(temp_root.join("ignored"))
@@ -81,7 +80,6 @@ fn end_to_end_search_path_can_be_repeated_for_multiple_roots() {
         .arg(temp_root.join("app1"))
         .arg("--search-path")
         .arg(temp_root.join("app2"))
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .output()
         .expect("run fixdpr");
@@ -149,7 +147,6 @@ fn end_to_end_search_path_dedupes_overlapping_roots() {
         .arg(&temp_root)
         .arg("--search-path")
         .arg(temp_root.join("app1"))
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .arg("--ignore-path")
         .arg(temp_root.join("ignored"))
@@ -222,7 +219,6 @@ fn end_to_end_search_path_requires_existing_directory() {
         .arg(&matched_root)
         .arg("--search-path")
         .arg(&missing_path)
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .output()
         .expect("run fixdpr");
@@ -259,7 +255,6 @@ fn end_to_end_ignores_dpr_with_absolute_pattern_and_reports_info() {
         .current_dir(&repo_root)
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .arg("--ignore-path")
         .arg(temp_root.join("ignored"))
@@ -319,7 +314,6 @@ fn end_to_end_relative_ignore_pattern_from_repo_root_does_not_match_temp_repo() 
         .current_dir(&repo_root)
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .arg("--ignore-path")
         .arg(temp_root.join("ignored"))
@@ -370,7 +364,6 @@ fn end_to_end_relative_ignore_pattern_from_search_root_matches() {
         .current_dir(&temp_root)
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .arg("--ignore-path")
         .arg("ignored")
@@ -420,7 +413,6 @@ fn end_to_end_delphi_path_enables_transitive_external_resolution() {
         .arg("add-dependency")
         .arg("--search-path")
         .arg(&without_project)
-        .arg("--new-dependency")
         .arg(without_delphi.join("NewUnit.pas"))
         .output()
         .expect("run fixdpr without delphi path");
@@ -449,7 +441,6 @@ fn end_to_end_delphi_path_enables_transitive_external_resolution() {
         .arg("add-dependency")
         .arg("--search-path")
         .arg(&with_project)
-        .arg("--new-dependency")
         .arg(with_delphi.join("NewUnit.pas"))
         .arg("--delphi-path")
         .arg(&with_delphi)
@@ -483,7 +474,6 @@ fn end_to_end_fix_dpr_delphi_path_enables_transitive_external_resolution() {
         .arg("fix-dpr")
         .arg("--search-path")
         .arg(&without_project)
-        .arg("--dpr-file")
         .arg(&without_target)
         .output()
         .expect("run fixdpr fix-dpr without delphi path");
@@ -517,7 +507,6 @@ fn end_to_end_fix_dpr_delphi_path_enables_transitive_external_resolution() {
         .arg("fix-dpr")
         .arg("--search-path")
         .arg(&with_project)
-        .arg("--dpr-file")
         .arg(&with_target)
         .arg("--delphi-path")
         .arg(&with_delphi)
@@ -557,7 +546,6 @@ fn end_to_end_delphi_version_reports_error_for_unknown_version() {
         .arg("add-dependency")
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .arg("--delphi-version")
         .arg("9999.9999")
@@ -599,7 +587,6 @@ fn end_to_end_fix_dpr_delphi_version_reports_error_for_unknown_version() {
         .arg("fix-dpr")
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--dpr-file")
         .arg(&target_dpr)
         .arg("--delphi-version")
         .arg("9999.9999")
@@ -637,7 +624,6 @@ fn end_to_end_adds_introduced_dependencies_by_default() {
         .arg("add-dependency")
         .arg("--search-path")
         .arg(&root)
-        .arg("--new-dependency")
         .arg(shared_root.join("NewUnit.pas"))
         .output()
         .expect("run fixdpr with introduced dependencies enabled");
@@ -677,7 +663,6 @@ fn end_to_end_disable_introduced_dependencies_flag_restores_single_insert_behavi
         .arg("add-dependency")
         .arg("--search-path")
         .arg(&root)
-        .arg("--new-dependency")
         .arg(shared_root.join("NewUnit.pas"))
         .arg("--disable-introduced-dependencies")
         .output()
@@ -726,7 +711,6 @@ fn end_to_end_add_dependency_can_run_fix_dpr_on_updated_files() {
         .arg("add-dependency")
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--new-dependency")
         .arg(&new_dependency)
         .arg("--ignore-path")
         .arg(temp_root.join("ignored"))
@@ -784,7 +768,6 @@ fn end_to_end_fix_dpr_repairs_missing_chain_for_target_file() {
         .arg("fix-dpr")
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--dpr-file")
         .arg(&target_dpr)
         .arg("--ignore-path")
         .arg(temp_root.join("ignored"))
@@ -837,7 +820,6 @@ fn end_to_end_fix_dpr_rejects_target_ignored_by_pattern() {
         .arg("fix-dpr")
         .arg("--search-path")
         .arg(&temp_root)
-        .arg("--dpr-file")
         .arg(&target_dpr)
         .arg("--ignore-dpr")
         .arg(&target_dpr)
@@ -853,7 +835,7 @@ fn end_to_end_fix_dpr_rejects_target_ignored_by_pattern() {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("--dpr-file is ignored by --ignore-dpr"),
+        stderr.contains("DPR_FILE is ignored by --ignore-dpr"),
         "{stderr}"
     );
 }


### PR DESCRIPTION
### Motivation
- Simplify the CLI by making the file targets positional for both subcommands so users don't need to pass `--new-dependency` or `--dpr-file` flags when the subcommand already indicates the mode.
- Make user-facing error messages and docs consistent with the new positional argument names.
- Ensure parsing and existing tests reflect the new form so end-to-end and unit tests validate the change.

### Description
- Changed `AddDependencyArgs.new_dependency` and `FixDprArgs.dpr_file` to be positional arguments by updating their `#[arg(...)]` attributes to use `value_name = "NEW_DEPENDENCY"` and `value_name = "DPR_FILE"` respectively, and updated helper/validation labels to match those names.
- Updated error and validation messages to reference `NEW_DEPENDENCY` / `DPR_FILE` instead of legacy flag names, and adjusted `resolve_*` helpers to use the new labels.
- Updated `tests/end_to_end.rs` command invocations and a related assertion to pass positional file arguments instead of legacy flags.
- Added unit tests that assert parsing accepts the new positional forms and that the legacy `--new-dependency` flag is rejected, and updated `README.md` to document the new positional usage and examples.

### Testing
- Ran `cargo build` and `cargo test` and all tests passed (`48` unit tests and `16` end-to-end tests ran successfully).
- Ran `cargo fmt -- --check` (after formatting fixes) with no problems and `cargo clippy --all-targets --all-features` which completed successfully while reporting pre-existing dead-code warnings in `src/delphi.rs`.
- Manually exercised the CLI via `cargo run -- add-dependency --search-path tests/fixtures/synthetic_repo tests/fixtures/synthetic_repo/common/NewUnit.pas --ignore-path tests/fixtures/synthetic_repo/ignored` and observed expected behavior and output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999cd2e50b8833095b47ba8477ed5a7)