### PR TITLE
Bump project version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "fixdpr"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "pathdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fixdpr"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
### Motivation
- Advance the crate version to `0.3.2` and keep the lockfile in sync so published metadata and local builds remain consistent.

### Description
- Updated the crate `version` in `Cargo.toml` to `0.3.2` and updated the corresponding `fixdpr` `version` entry in `Cargo.lock`.

### Testing
- Ran `cargo test`, which executed the unit and end-to-end suites (48 unit tests and 16 end-to-end tests) and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999df9771f483308e2fd76cf3d63491)