### PR TITLE
Add `delete-dependency` mode to remove units and cascade orphaned removals

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 CLI tool that updates Delphi `.dpr` program files.
 
-It now supports three modes:
+It now supports four modes:
 
 - `add-dependency`: existing behavior. Add a given new unit to `.dpr` files that require it.
 - `insert-dependency`: insert a given new unit into selected `.dpr` files whether or not they currently depend on it, and optionally add that new unit's transitive dependency chain.
+- `delete-dependency`: remove a given unit from selected `.dpr` files and also remove transitive dependencies that are no longer required by any remaining `.dpr` entry.
 - `fix-dpr`: new behavior. Repair one target `.dpr` by traversing dependency chains from its existing `uses` entries and adding missing units found in the scanned search-path unit cache.
 
 ## Usage
@@ -16,6 +17,10 @@ fixdpr add-dependency NEW_DEPENDENCY --search-path PATH [--search-path PATH] [--
 
 ```powershell
 fixdpr insert-dependency NEW_DEPENDENCY --search-path PATH [--search-path PATH] (--target-path PATH | --target-dpr DPR_FILE) [--target-path PATH] [--target-dpr DPR_FILE] [--delphi-path PATH] [--delphi-version VERSION] [--ignore-path PATH] [--ignore-dpr GLOB] [--disable-introduced-dependencies] [--show-infos] [--show-warnings]
+```
+
+```powershell
+fixdpr delete-dependency OLD_DEPENDENCY --search-path PATH [--search-path PATH] (--target-path PATH | --target-dpr DPR_FILE) [--target-path PATH] [--target-dpr DPR_FILE] [--delphi-path PATH] [--delphi-version VERSION] [--ignore-path PATH] [--ignore-dpr GLOB] [--show-infos] [--show-warnings]
 ```
 
 ```powershell
@@ -52,6 +57,13 @@ fixdpr fix-dpr DPR_FILE --search-path PATH [--search-path PATH] [--delphi-path P
 
 - `DPR_FILE`: Target `.dpr` file to repair (absolute or relative to the current working directory).
 
+### `delete-dependency` arguments
+
+- `OLD_DEPENDENCY`: A `.pas` file path (absolute or relative to the current working directory).
+- `--target-path PATH`: Directory whose `.dpr` files should be updated recursively; can be repeated. Each target path must sit under one of the `--search-path` roots.
+- `--target-dpr DPR_FILE`: Exact `.dpr` file to update; can be repeated. Each target `.dpr` must sit under one of the `--search-path` roots.
+- `--ignore-dpr GLOB`: Optional `.dpr` glob pattern to ignore; can be repeated. Relative patterns are resolved from the current working directory, then matched against absolute `.dpr` paths.
+
 ## Examples
 
 Add a new dependency for all matching `.dpr` files:
@@ -87,6 +99,24 @@ fixdpr insert-dependency `
   --search-path .\repo `
   --target-dpr .\repo\special\LegacyApp.dpr `
   --disable-introduced-dependencies
+```
+
+Delete dependency from selected `.dpr` files and cascade orphaned removals:
+
+```powershell
+fixdpr delete-dependency `
+  .\repo\common\LegacyUnit.pas `
+  --search-path .\repo `
+  --target-path .\repo\apps
+```
+
+Delete dependency from one explicit `.dpr` file:
+
+```powershell
+fixdpr delete-dependency `
+  .\repo\common\LegacyUnit.pas `
+  --search-path .\repo `
+  --target-dpr .\repo\apps\App1\App1.dpr
 ```
 
 Add dependency and then run fix pass on all updated `.dpr` files:

--- a/src/dpr_edit.rs
+++ b/src/dpr_edit.rs
@@ -683,6 +683,257 @@ pub fn fix_dpr_file(
     Ok(summary)
 }
 
+pub fn delete_dependency_files(
+    dpr_paths: &[PathBuf],
+    project_cache: &UnitCache,
+    delphi_cache: Option<&UnitCache>,
+    old_dependency_name: &str,
+) -> io::Result<DprUpdateSummary> {
+    let mut summary = DprUpdateSummary {
+        scanned: 0,
+        updated: 0,
+        updated_paths: Vec::new(),
+        warnings: Vec::new(),
+        failures: 0,
+    };
+
+    for path in dpr_paths {
+        summary.scanned += 1;
+        let bytes = match fs::read(path) {
+            Ok(data) => data,
+            Err(err) => {
+                summary.warnings.push(format!(
+                    "warning: failed to read dpr {}: {err}",
+                    path.display()
+                ));
+                summary.failures += 1;
+                continue;
+            }
+        };
+        let Some(list) = parse_dpr_uses(path, &bytes, &mut summary.warnings) else {
+            continue;
+        };
+
+        let removal_set = match collect_cascading_delete_names(
+            path,
+            &list,
+            project_cache,
+            delphi_cache,
+            old_dependency_name,
+            &mut summary.warnings,
+        )? {
+            Some(set) => set,
+            None => continue,
+        };
+
+        if !can_delete_entries(path, &list, &removal_set, &mut summary.warnings) {
+            continue;
+        }
+
+        let updated = match delete_uses_entries(path, &bytes, &list, &removal_set) {
+            Ok(value) => value,
+            Err(err) => {
+                summary.warnings.push(format!(
+                    "warning: failed to update dpr {}: {err}",
+                    path.display()
+                ));
+                summary.failures += 1;
+                continue;
+            }
+        };
+        if updated {
+            summary.updated += 1;
+            summary.updated_paths.push(path.clone());
+        }
+    }
+
+    Ok(summary)
+}
+
+fn can_delete_entries(
+    dpr_path: &Path,
+    list: &UsesList,
+    removal_set: &HashSet<String>,
+    warnings: &mut Vec<String>,
+) -> bool {
+    for entry in &list.entries {
+        let key = entry.name.to_ascii_lowercase();
+        if !removal_set.contains(&key) {
+            continue;
+        }
+        if !entry.from_include {
+            continue;
+        }
+        warnings.push(format!(
+            "warning: cannot remove unit {} from {} because it originates from include fragment",
+            entry.name,
+            dpr_path.display()
+        ));
+        return false;
+    }
+    true
+}
+
+fn delete_uses_entries(
+    dpr_path: &Path,
+    bytes: &[u8],
+    list: &UsesList,
+    removal_set: &HashSet<String>,
+) -> io::Result<bool> {
+    let mut kept = Vec::new();
+    for entry in &list.entries {
+        let key = entry.name.to_ascii_lowercase();
+        if removal_set.contains(&key) {
+            continue;
+        }
+        if entry.from_include {
+            return Ok(false);
+        }
+        kept.push(entry);
+    }
+
+    if kept.is_empty() {
+        return Ok(false);
+    }
+
+    let list_start = list
+        .entries
+        .first()
+        .map(|entry| entry.start)
+        .unwrap_or(list.semicolon);
+    let new_body = render_uses_entries(list, &kept);
+
+    let mut output = Vec::with_capacity(bytes.len() + new_body.len());
+    output.extend_from_slice(&bytes[..list_start]);
+    output.extend_from_slice(new_body.as_bytes());
+    output.extend_from_slice(&bytes[list.semicolon..]);
+    write_atomic(dpr_path, &output)?;
+    Ok(true)
+}
+
+fn render_uses_entries(list: &UsesList, entries: &[&UsesEntry]) -> String {
+    if list.multiline {
+        let mut output = String::new();
+        for (idx, entry) in entries.iter().enumerate() {
+            if idx > 0 {
+                output.push(',');
+                output.push('\n');
+                output.push_str(&list.indent);
+            }
+            output.push_str(&entry.name);
+            if let Some(in_path) = entry.in_path.as_ref() {
+                output.push_str(" in '");
+                output.push_str(in_path);
+                output.push('\'');
+            }
+        }
+        output
+    } else {
+        let mut parts = Vec::new();
+        for entry in entries {
+            if let Some(in_path) = entry.in_path.as_ref() {
+                parts.push(format!("{} in '{}'", entry.name, in_path));
+            } else {
+                parts.push(entry.name.clone());
+            }
+        }
+        parts.join(", ")
+    }
+}
+
+fn collect_cascading_delete_names(
+    dpr_path: &Path,
+    list: &UsesList,
+    project_cache: &UnitCache,
+    delphi_cache: Option<&UnitCache>,
+    old_dependency_name: &str,
+    warnings: &mut Vec<String>,
+) -> io::Result<Option<HashSet<String>>> {
+    let root_key = old_dependency_name.to_ascii_lowercase();
+    let mut present = HashSet::new();
+    for entry in &list.entries {
+        present.insert(entry.name.to_ascii_lowercase());
+    }
+    if !present.contains(&root_key) {
+        return Ok(None);
+    }
+
+    let project_map = build_project_map(dpr_path, list, project_cache, delphi_cache, warnings);
+    let mut edges: HashMap<String, HashSet<String>> = HashMap::new();
+    let mut incoming: HashMap<String, usize> = HashMap::new();
+    for key in &present {
+        incoming.insert(key.clone(), 0);
+    }
+
+    for key in &present {
+        let Some(unit_path) = project_map.get(key) else {
+            continue;
+        };
+        let uses = match load_unit_uses_readonly(project_cache, delphi_cache, unit_path, warnings)?
+        {
+            Some(value) => value,
+            None => continue,
+        };
+        for dep_name in uses {
+            let dep_key = dep_name.to_ascii_lowercase();
+            if !present.contains(&dep_key) {
+                continue;
+            }
+            let inserted = edges
+                .entry(key.clone())
+                .or_default()
+                .insert(dep_key.clone());
+            if inserted {
+                *incoming.entry(dep_key).or_default() += 1;
+            }
+        }
+    }
+
+    let mut removed = HashSet::new();
+    let mut queue = VecDeque::new();
+    removed.insert(root_key.clone());
+    queue.push_back(root_key);
+
+    while let Some(current) = queue.pop_front() {
+        let Some(children) = edges.get(&current) else {
+            continue;
+        };
+        for child in children {
+            if removed.contains(child) {
+                continue;
+            }
+            if let Some(count) = incoming.get_mut(child) {
+                *count = count.saturating_sub(1);
+                if *count == 0 {
+                    removed.insert(child.clone());
+                    queue.push_back(child.clone());
+                }
+            }
+        }
+    }
+
+    Ok(Some(removed))
+}
+
+fn load_unit_uses_readonly(
+    project_cache: &UnitCache,
+    delphi_cache: Option<&UnitCache>,
+    unit_path: &Path,
+    warnings: &mut Vec<String>,
+) -> io::Result<Option<Vec<String>>> {
+    let canonical = unit_cache::canonicalize_if_exists(unit_path);
+    if let Some(info) = project_cache.by_path.get(&canonical) {
+        return Ok(Some(info.uses.clone()));
+    }
+    if let Some(delphi_cache) = delphi_cache {
+        if let Some(info) = delphi_cache.by_path.get(&canonical) {
+            return Ok(Some(info.uses.clone()));
+        }
+    }
+
+    Ok(unit_cache::load_unit_file(&canonical, warnings)?.map(|info| info.uses))
+}
+
 fn collect_fix_root_paths(
     dpr_path: &Path,
     list: &UsesList,
@@ -2360,6 +2611,104 @@ begin end.
         );
         assert!(updated.contains("MidUnit in 'MidUnit.pas',"), "{updated}");
         assert!(updated.contains("BaseUnit in 'BaseUnit.pas';"), "{updated}");
+    }
+
+    #[test]
+    fn delete_dependency_files_removes_root_and_orphaned_dependencies() {
+        let root = temp_dir();
+        let dpr_path = root.join("App.dpr");
+        let unit_a = root.join("UnitA.pas");
+        let old_unit = root.join("OldUnit.pas");
+        let leaf_only = root.join("LeafOnly.pas");
+        let shared_dep = root.join("SharedDep.pas");
+        let keep_unit = root.join("KeepUnit.pas");
+
+        fs::write(
+            &dpr_path,
+            "program App;\nuses\n  UnitA in 'UnitA.pas',\n  OldUnit in 'OldUnit.pas',\n  LeafOnly in 'LeafOnly.pas',\n  SharedDep in 'SharedDep.pas',\n  KeepUnit in 'KeepUnit.pas';\nbegin\nend.\n",
+        )
+        .unwrap();
+        fs::write(
+            &unit_a,
+            "unit UnitA;\ninterface\nuses KeepUnit;\nimplementation\nend.\n",
+        )
+        .unwrap();
+        fs::write(
+            &old_unit,
+            "unit OldUnit;\ninterface\nuses LeafOnly, SharedDep;\nimplementation\nend.\n",
+        )
+        .unwrap();
+        fs::write(
+            &keep_unit,
+            "unit KeepUnit;\ninterface\nuses SharedDep;\nimplementation\nend.\n",
+        )
+        .unwrap();
+        fs::write(
+            &leaf_only,
+            "unit LeafOnly;\ninterface\nimplementation\nend.\n",
+        )
+        .unwrap();
+        fs::write(
+            &shared_dep,
+            "unit SharedDep;\ninterface\nimplementation\nend.\n",
+        )
+        .unwrap();
+
+        let mut warnings = Vec::new();
+        let cache = unit_cache::build_unit_cache(
+            &[
+                unit_a.clone(),
+                old_unit.clone(),
+                leaf_only.clone(),
+                shared_dep.clone(),
+                keep_unit.clone(),
+            ],
+            &mut warnings,
+        )
+        .unwrap();
+
+        let result =
+            delete_dependency_files(std::slice::from_ref(&dpr_path), &cache, None, "OldUnit")
+                .unwrap();
+        assert_eq!(result.failures, 0, "{result:?}");
+        assert_eq!(result.updated, 1, "{result:?}");
+
+        let updated = fs::read_to_string(&dpr_path).unwrap();
+        assert!(!updated.contains("OldUnit in 'OldUnit.pas'"), "{updated}");
+        assert!(!updated.contains("LeafOnly in 'LeafOnly.pas'"), "{updated}");
+        assert!(
+            updated.contains("SharedDep in 'SharedDep.pas'"),
+            "{updated}"
+        );
+        assert!(updated.contains("KeepUnit in 'KeepUnit.pas'"), "{updated}");
+    }
+
+    #[test]
+    fn delete_dependency_files_is_noop_when_root_not_present() {
+        let root = temp_dir();
+        let dpr_path = root.join("App.dpr");
+        let keep_unit = root.join("KeepUnit.pas");
+
+        fs::write(
+            &dpr_path,
+            "program App;\nuses\n  KeepUnit in 'KeepUnit.pas';\nbegin\nend.\n",
+        )
+        .unwrap();
+        fs::write(
+            &keep_unit,
+            "unit KeepUnit;\ninterface\nimplementation\nend.\n",
+        )
+        .unwrap();
+
+        let mut warnings = Vec::new();
+        let cache =
+            unit_cache::build_unit_cache(std::slice::from_ref(&keep_unit), &mut warnings).unwrap();
+
+        let result =
+            delete_dependency_files(std::slice::from_ref(&dpr_path), &cache, None, "OldUnit")
+                .unwrap();
+        assert_eq!(result.failures, 0, "{result:?}");
+        assert_eq!(result.updated, 0, "{result:?}");
     }
 
     fn temp_dir() -> PathBuf {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,8 @@ enum Commands {
     AddDependency(AddDependencyArgs),
     /// Insert a specific dependency into selected .dpr files regardless of current usage
     InsertDependency(InsertDependencyArgs),
+    /// Remove a specific dependency from selected .dpr files and cascade orphan cleanup
+    DeleteDependency(DeleteDependencyArgs),
     /// Fix a single .dpr file by adding missing dependencies in its uses chain
     FixDpr(FixDprArgs),
 }
@@ -90,6 +92,30 @@ struct InsertDependencyArgs {
     /// Disable adding transitive dependencies introduced by NEW_DEPENDENCY
     #[arg(long)]
     disable_introduced_dependencies: bool,
+}
+
+#[derive(Args, Debug)]
+struct DeleteDependencyArgs {
+    #[command(flatten)]
+    common: SharedArgs,
+
+    #[command(flatten)]
+    dpr_filter: AddDependencyDprFilterArgs,
+
+    #[command(flatten)]
+    targets: InsertDependencyTargetArgs,
+
+    /// Optional Delphi/VCL source root path to scan for fallback unit resolution (repeatable)
+    #[arg(long, value_name = "PATH", action = clap::ArgAction::Append)]
+    delphi_path: Vec<String>,
+
+    /// Optional Delphi version to resolve from registry and use as fallback source root (repeatable)
+    #[arg(long, value_name = "VERSION", action = clap::ArgAction::Append)]
+    delphi_version: Vec<String>,
+
+    /// Path to a .pas file (absolute or relative to the current directory)
+    #[arg(value_name = "OLD_DEPENDENCY")]
+    old_dependency: String,
 }
 
 #[derive(Args, Debug)]
@@ -158,6 +184,7 @@ fn main() {
     match cli.command {
         Commands::AddDependency(args) => run_add_dependency(args),
         Commands::InsertDependency(args) => run_insert_dependency(args),
+        Commands::DeleteDependency(args) => run_delete_dependency(args),
         Commands::FixDpr(args) => run_fix_dpr(args),
     }
 }
@@ -690,6 +717,191 @@ fn run_insert_dependency(args: InsertDependencyArgs) {
     }
 }
 
+fn run_delete_dependency(args: DeleteDependencyArgs) {
+    let cwd = match env::current_dir() {
+        Ok(path) => path,
+        Err(err) => exit_with_error(format!("failed to read current directory: {err}"), 2),
+    };
+    let cwd = fs_walk::canonicalize_root(&cwd);
+
+    let search_roots = match fs_walk::resolve_search_roots(&args.common.search_path, &cwd) {
+        Ok(roots) => roots,
+        Err(err) => exit_with_error(err, 2),
+    };
+    let target_paths =
+        match fs_walk::resolve_optional_roots(&args.targets.target_path, &cwd, "--target-path") {
+            Ok(paths) => paths,
+            Err(err) => exit_with_error(err, 2),
+        };
+    if let Err(err) = ensure_paths_under_search_roots(&target_paths, &search_roots, "--target-path")
+    {
+        exit_with_error(err, 2);
+    }
+
+    let target_dprs = match resolve_target_dpr_paths(&args.targets.target_dpr, &cwd) {
+        Ok(paths) => paths,
+        Err(err) => exit_with_error(err, 2),
+    };
+    if let Err(err) = ensure_paths_under_search_roots(&target_dprs, &search_roots, "--target-dpr") {
+        exit_with_error(err, 2);
+    }
+
+    let mut delphi_roots =
+        match fs_walk::resolve_optional_roots(&args.delphi_path, &cwd, "--delphi-path") {
+            Ok(roots) => roots,
+            Err(err) => exit_with_error(err, 2),
+        };
+    let mut delphi_roots_from_version = match delphi::resolve_source_roots(&args.delphi_version) {
+        Ok(roots) => roots,
+        Err(err) => exit_with_error(err, 2),
+    };
+    delphi_roots.append(&mut delphi_roots_from_version);
+    delphi_roots = dedupe_paths(delphi_roots);
+
+    let old_dependency_path = match resolve_new_dependency_path(&args.old_dependency, &cwd) {
+        Ok(path) => path,
+        Err(err) => exit_with_error(err, 2),
+    };
+    if let Err(err) = validate_new_dependency_path(&old_dependency_path) {
+        exit_with_error(err, 2);
+    }
+
+    let ignore_matcher = match fs_walk::build_ignore_matcher(&args.common.ignore_path, &cwd) {
+        Ok(matcher) => matcher,
+        Err(err) => exit_with_error(err, 2),
+    };
+    let ignore_dpr_matcher =
+        match fs_walk::build_dpr_ignore_matcher(&args.dpr_filter.ignore_dpr, &cwd) {
+            Ok(matcher) => matcher,
+            Err(err) => exit_with_error(err, 2),
+        };
+
+    let mut warnings = Vec::new();
+    println!("fixdpr {}", env!("CARGO_PKG_VERSION"));
+    println!("Mode: delete-dependency");
+    println!("Scanning {} root(s):", search_roots.len());
+    for root in &search_roots {
+        println!("  {}", root.display());
+    }
+    if !delphi_roots.is_empty() {
+        println!("Delphi fallback roots ({}):", delphi_roots.len());
+        for root in &delphi_roots {
+            println!("  {}", root.display());
+        }
+    }
+    let delphi_version_display = format_values(&args.delphi_version);
+    if !delphi_version_display.is_empty() {
+        println!("Delphi version lookup: {}", delphi_version_display);
+    }
+    let ignore_display = format_values(&args.common.ignore_path);
+    if !ignore_display.is_empty() {
+        println!("Ignoring: {}", ignore_display);
+    }
+    let ignore_dpr_display = format_values(ignore_dpr_matcher.normalized_patterns());
+    if !ignore_dpr_display.is_empty() {
+        println!("Ignoring dpr (absolute): {}", ignore_dpr_display);
+    }
+
+    let scan = match fs_walk::scan_files(&search_roots, &ignore_matcher) {
+        Ok(result) => result,
+        Err(err) => exit_with_error(err.to_string(), 1),
+    };
+    let (target_dpr_files, ignored_target_dprs) = match select_target_dpr_files(
+        &scan.dpr_files,
+        &target_paths,
+        &target_dprs,
+        &ignore_dpr_matcher,
+    ) {
+        Ok(value) => value,
+        Err(err) => exit_with_error(err, 2),
+    };
+    let mut infos = Vec::new();
+    for path in &ignored_target_dprs {
+        infos.push(format!("info: ignored dpr {}", path.display()));
+    }
+
+    println!(
+        "Found {} .pas, {} .dpr",
+        scan.pas_files.len(),
+        scan.dpr_files.len()
+    );
+    println!("Updating selected .dpr files... {}", target_dpr_files.len());
+    println!("Building unit cache...");
+    let unit_cache = match unit_cache::build_unit_cache(&scan.pas_files, &mut warnings) {
+        Ok(result) => result,
+        Err(err) => exit_with_error(err.to_string(), 1),
+    };
+    println!("Unit cache ready ({} units)", scan.pas_files.len());
+
+    let delphi_unit_cache = if delphi_roots.is_empty() {
+        None
+    } else {
+        println!("Scanning Delphi fallback roots...");
+        let delphi_scan =
+            match fs_walk::scan_files(&delphi_roots, &fs_walk::IgnoreMatcher::default()) {
+                Ok(result) => result,
+                Err(err) => exit_with_error(err.to_string(), 1),
+            };
+        println!("Found {} fallback .pas", delphi_scan.pas_files.len());
+        println!("Building Delphi fallback unit cache...");
+        let cache = match unit_cache::build_unit_cache(&delphi_scan.pas_files, &mut warnings) {
+            Ok(result) => result,
+            Err(err) => exit_with_error(err.to_string(), 1),
+        };
+        println!(
+            "Delphi fallback unit cache ready ({} units)",
+            cache.by_path.len()
+        );
+        Some(cache)
+    };
+
+    let old_dependency_path = unit_cache::canonicalize_if_exists(&old_dependency_path);
+    let old_unit = match unit_cache::load_unit_file(&old_dependency_path, &mut warnings) {
+        Ok(Some(unit)) => unit,
+        Ok(None) => {
+            exit_with_error(
+                format!(
+                    "unable to determine unit name from old dependency: {}",
+                    old_dependency_path.display()
+                ),
+                1,
+            );
+        }
+        Err(err) => exit_with_error(err.to_string(), 1),
+    };
+    println!(
+        "Old dependency: {} ({})",
+        old_unit.name,
+        old_unit.path.display()
+    );
+
+    let dpr_summary = match dpr_edit::delete_dependency_files(
+        &target_dpr_files,
+        &unit_cache,
+        delphi_unit_cache.as_ref(),
+        &old_unit.name,
+    ) {
+        Ok(summary) => summary,
+        Err(err) => exit_with_error(err.to_string(), 1),
+    };
+    warnings.extend(dpr_summary.warnings.iter().cloned());
+
+    print_summary(SummaryOutput {
+        infos: &infos,
+        warnings: &warnings,
+        show_infos: args.common.show_infos,
+        show_warnings: args.common.show_warnings,
+        pas_scanned: scan.pas_files.len(),
+        dpr_summary: &dpr_summary,
+        ignored_dpr: ignored_target_dprs.len(),
+        search_roots: &search_roots,
+    });
+
+    if dpr_summary.failures > 0 {
+        process::exit(1);
+    }
+}
+
 struct SummaryOutput<'a> {
     infos: &'a [String],
     warnings: &'a [String],
@@ -1021,5 +1233,20 @@ mod tests {
             parsed.is_err(),
             "--ignore-dpr should not parse in fix-dpr mode"
         );
+    }
+
+    #[test]
+    fn parse_delete_dependency_with_target_path() {
+        let parsed = Cli::try_parse_from([
+            "fixdpr",
+            "delete-dependency",
+            "--search-path",
+            ".",
+            "--target-path",
+            "./apps",
+            "./common/LegacyUnit.pas",
+        ]);
+
+        assert!(parsed.is_ok(), "{parsed:?}");
     }
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -235,6 +235,48 @@ fn end_to_end_search_path_requires_existing_directory() {
 }
 
 #[test]
+fn end_to_end_delete_dependency_removes_orphaned_dependencies() {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_root = repo_root.join("tests").join("fixtures").join("delete_repo");
+    let expected_root = repo_root
+        .join("tests")
+        .join("fixtures")
+        .join("delete_expected");
+    let temp_root = temp_dir("fixdpr_e2e_delete_");
+    copy_dir(&fixture_root, &temp_root);
+
+    let old_dependency = temp_root.join("common").join("OldUnit.pas");
+    let target_dpr = temp_root.join("app").join("App.dpr");
+    let output = Command::new(env!("CARGO_BIN_EXE_fixdpr"))
+        .arg("delete-dependency")
+        .arg("--search-path")
+        .arg(&temp_root)
+        .arg("--target-dpr")
+        .arg(&target_dpr)
+        .arg(&old_dependency)
+        .output()
+        .expect("run fixdpr");
+
+    assert!(
+        output.status.success(),
+        "stdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = normalize_newlines(
+        fs::read_to_string(temp_root.join("app").join("App.dpr")).expect("read app actual"),
+    );
+    let expected = normalize_newlines(
+        fs::read_to_string(expected_root.join("app").join("App.dpr")).expect("read app expected"),
+    );
+    assert_eq!(
+        actual, expected,
+        "delete-dependency should remove OldUnit and LeafOnly only"
+    );
+}
+
+#[test]
 fn end_to_end_ignores_dpr_with_absolute_pattern_and_reports_info() {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let fixture_root = repo_root

--- a/tests/fixtures/delete_expected/app/App.dpr
+++ b/tests/fixtures/delete_expected/app/App.dpr
@@ -1,0 +1,9 @@
+program App;
+
+uses
+  UnitA in 'UnitA.pas',
+  SharedDep in '..\\common\\SharedDep.pas',
+  KeepUnit in '..\\common\\KeepUnit.pas';
+
+begin
+end.

--- a/tests/fixtures/delete_repo/app/App.dpr
+++ b/tests/fixtures/delete_repo/app/App.dpr
@@ -1,0 +1,11 @@
+program App;
+
+uses
+  UnitA in 'UnitA.pas',
+  OldUnit in '..\\common\\OldUnit.pas',
+  LeafOnly in '..\\common\\LeafOnly.pas',
+  SharedDep in '..\\common\\SharedDep.pas',
+  KeepUnit in '..\\common\\KeepUnit.pas';
+
+begin
+end.

--- a/tests/fixtures/delete_repo/app/UnitA.pas
+++ b/tests/fixtures/delete_repo/app/UnitA.pas
@@ -1,0 +1,10 @@
+unit UnitA;
+
+interface
+
+uses
+  KeepUnit;
+
+implementation
+
+end.

--- a/tests/fixtures/delete_repo/common/KeepUnit.pas
+++ b/tests/fixtures/delete_repo/common/KeepUnit.pas
@@ -1,0 +1,10 @@
+unit KeepUnit;
+
+interface
+
+uses
+  SharedDep;
+
+implementation
+
+end.

--- a/tests/fixtures/delete_repo/common/LeafOnly.pas
+++ b/tests/fixtures/delete_repo/common/LeafOnly.pas
@@ -1,0 +1,7 @@
+unit LeafOnly;
+
+interface
+
+implementation
+
+end.

--- a/tests/fixtures/delete_repo/common/OldUnit.pas
+++ b/tests/fixtures/delete_repo/common/OldUnit.pas
@@ -1,0 +1,11 @@
+unit OldUnit;
+
+interface
+
+uses
+  LeafOnly,
+  SharedDep;
+
+implementation
+
+end.

--- a/tests/fixtures/delete_repo/common/SharedDep.pas
+++ b/tests/fixtures/delete_repo/common/SharedDep.pas
@@ -1,0 +1,7 @@
+unit SharedDep;
+
+interface
+
+implementation
+
+end.


### PR DESCRIPTION
### Motivation

- Provide a new operation to remove a specified unit from selected `.dpr` files and automatically remove any transitive (orphaned) dependencies no longer required. 

### Description

- Documented the new `delete-dependency` command and examples in `README.md`. 
- Added CLI support including a new `DeleteDependencyArgs` struct and a `delete-dependency` subcommand wired to `run_delete_dependency` in `main.rs`. 
- Implemented deletion logic in `dpr_edit.rs` with `delete_dependency_files` and helper functions `collect_cascading_delete_names`, `delete_uses_entries`, `can_delete_entries`, `render_uses_entries`, and `load_unit_uses_readonly` to compute cascaded removals and safely update `.dpr` files. 
- Added unit tests for the deletion behavior and CLI parsing and added an end-to-end test plus fixtures under `tests/fixtures/delete_repo` and `tests/fixtures/delete_expected` to verify full behavior. 

### Testing

- Added unit tests `delete_dependency_files_removes_root_and_orphaned_dependencies`, `delete_dependency_files_is_noop_when_root_not_present`, and `parse_delete_dependency_with_target_path`, all executed via `cargo test` and passing. 
- Added end-to-end test `end_to_end_delete_dependency_removes_orphaned_dependencies` which runs the built `fixdpr` binary against the provided fixtures and passed when executed as part of the test suite. 
- Existing test suite was run (`cargo test`) and the new tests passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b00e4af5e88330afaa5ce4dc68b2d0)